### PR TITLE
Remove fireActionCreator

### DIFF
--- a/examples/example/actions/movie-actions.js
+++ b/examples/example/actions/movie-actions.js
@@ -2,62 +2,47 @@ import actionTypes from '../constants/action-types';
 import MovieService from '../service/movie-service';
 
 const MovieActions = {
-  fetchMovie(id, existingMovie) {
-    if (id) {
-      return {
-        storeIds: ['movie'],
-        actionCreator: (dispatchAction, state) => {
-          const movies = state.get('movieState').get('movies');
-          if (movies.has(id)) {
-            return;
-          }
+  fetchMovie(id) {
+    return {
+      storeIds: ['movie'],
+      actionCreator: (dispatchAction, state) => {
+        const movies = state.get('movieState').get('movies');
+        if (movies.has(id)) {
+          return;
+        }
 
+        dispatchAction({
+          id,
+          actionType: actionTypes.FETCH_MOVIE_PENDING,
+        });
+
+        MovieService.fetchMovie(id).then((movie) => {
           dispatchAction({
             id,
-            actionType: actionTypes.FETCH_MOVIE_PENDING,
+            movie,
+            actionType: actionTypes.FETCH_MOVIE_SUCCESS,
           });
-
-          MovieService.fetchMovie(id).then((movie) => {
-            dispatchAction({
-              id,
-              movie,
-              actionType: actionTypes.FETCH_MOVIE_SUCCESS,
-            });
-          }, (error) => {
-            dispatchAction({
-              id,
-              error,
-              actionType: actionTypes.FETCH_MOVIE_ERROR,
-            });
+        }, (error) => {
+          dispatchAction({
+            id,
+            error,
+            actionType: actionTypes.FETCH_MOVIE_ERROR,
           });
-        },
-      };
-    }
-
-    return (dispatchAction) => {
-      dispatchAction({
-        id: existingMovie.id,
-        movie: existingMovie,
-        actionType: actionTypes.FETCH_MOVIE_SUCCESS,
-      });
+        });
+      },
     };
   },
 
   fetchMovies() {
-    return (dispatchAction, fireActionCreator) => {
+    return (dispatchAction) => {
       dispatchAction({
         actionType: actionTypes.FETCH_MOVIES_PENDING,
       });
 
       MovieService.fetchMovies().then((movies) => {
-        movies.forEach(movie => {
-          fireActionCreator(
-            this.fetchMovie(null, movie)
-          );
-        });
-
         dispatchAction({
           actionType: actionTypes.FETCH_MOVIES_SUCCESS,
+          movies,
         });
       }, (error) => {
         dispatchAction({

--- a/examples/example/stores/movie-store.js
+++ b/examples/example/stores/movie-store.js
@@ -69,6 +69,16 @@ class TodoStore extends BaseStore {
   }
 
   _handleFetchMoviesSuccess(action, state) {
+    const {movies} = action;
+
+    movies.forEach(movie => {
+      state = state.setIn(['movies', movie.id], Immutable.fromJS({
+        id: movie.id,
+        movie,
+        status: 'success',
+      }));
+    });
+
     return state.set('status', 'success');
   }
 

--- a/src/app.js
+++ b/src/app.js
@@ -43,15 +43,14 @@ class App extends EventEmitter {
 
   fireActionCreator(actionCreator) {
     const dispatchAction = this._dispatcher.handleAction.bind(this._dispatcher);
-    const boundFireActionCreator = this.fireActionCreator.bind(this);
 
     if (typeof actionCreator === 'function') {
-      actionCreator(dispatchAction, boundFireActionCreator);
+      actionCreator(dispatchAction);
     } else {
       const storeIds = actionCreator.storeIds;
       const state = this.getStateFromStores(storeIds);
       const func = actionCreator.actionCreator;
-      return func(dispatchAction, state, boundFireActionCreator);
+      return func(dispatchAction, state);
     }
   }
 


### PR DESCRIPTION
If we move the "handler" logic from the movie actions to the movie store, we don't need the second `fireActionCreator` parameter anymore.
Instead of firing `n` actions for each one of the movies, we can just attach all the movies to the `FETCH_MOVIES_SUCCESS` action and let the store save every single object (no matter if they are in the same store or in a different one, we already got the action).
This change simplifies/standardises a bit the `fetchMovie` action as well.
