### PR TITLE
100% test coverage of app.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-react": "3.6.2",
     "nyc": "^5.5.0",
     "react-hot-loader": "1.3.0",
+    "sinon": "1.17.3",
     "webpack": "1.12.2",
     "webpack-dev-server": "1.12.1"
   },

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -1,7 +1,9 @@
 import 'babel-register';
 
 import Immutable from 'immutable';
+
 import test from 'ava';
+import sinon from 'sinon';
 
 import App from '../src/app';
 import TestStore from './helpers/test-store';
@@ -79,6 +81,48 @@ test('fireActionCreator calls actionCreator with expected inputs', t => {
     t.ok(typeof dispatchAction === 'function');
     t.ok(typeof fireActionCreator === 'function');
   });
+});
+
+test('undo calls through to ImmutableHistory redo', t => {
+  const app = new App('test', [
+    TestStore,
+  ]);
+
+  sinon.spy(app._history, 'redo');
+  t.plan(1);
+
+  app.redo();
+  t.ok(app._history.redo.calledOnce);
+});
+
+test('undo calls through to ImmutableHistory undo', t => {
+  const app = new App('test', [TestStore]);
+
+  sinon.spy(app._history, 'undo');
+  t.plan(1);
+
+  app.undo();
+  t.ok(app._history.undo.calledOnce);
+});
+
+test('undo calls through to ImmutableHistory canRedo', t => {
+  const app = new App('test', [TestStore]);
+
+  sinon.spy(app._history, 'canRedo');
+  t.plan(1);
+
+  app.canRedo();
+  t.ok(app._history.canRedo.calledOnce);
+});
+
+test('undo calls through to ImmutableHistory canUndo', t => {
+  const app = new App('test', [TestStore]);
+
+  sinon.spy(app._history, 'canUndo');
+  t.plan(1);
+
+  app.canUndo();
+  t.ok(app._history.canUndo.calledOnce);
 });
 
 test('fireActionCreator provides actionCreator with specified store state', t => {

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -89,17 +89,17 @@ test('app handles subscription and unsubscription EventEmitter lifecycle cleanly
 
   app.subscribe(cb);
 
-  t.ok(app.on.calledOnce);
-  t.ok(app.on.getCall(0).args[0] === 'CHANGE');
-  t.ok(app.on.getCall(0).args[1] === cb);
-  t.ok(app.listenerCount('CHANGE') === 1);
+  t.true(app.on.calledOnce);
+  t.is(app.on.getCall(0).args[0], 'CHANGE');
+  t.is(app.on.getCall(0).args[1], cb);
+  t.is(app.listenerCount('CHANGE'), 1);
 
   app.unsubscribe(cb);
 
-  t.ok(app.removeListener.calledOnce);
-  t.ok(app.removeListener.getCall(0).args[0] === 'CHANGE');
-  t.ok(app.removeListener.getCall(0).args[1] === cb);
-  t.ok(app.listenerCount('CHANGE') === 0);
+  t.true(app.removeListener.calledOnce);
+  t.is(app.removeListener.getCall(0).args[0], 'CHANGE');
+  t.is(app.removeListener.getCall(0).args[1], cb);
+  t.is(app.listenerCount('CHANGE'), 0);
 });
 
 test('fireActionCreator calls actionCreator with expected inputs', t => {
@@ -134,7 +134,7 @@ test('undo calls through to ImmutableHistory redo', t => {
   t.plan(1);
 
   app.redo();
-  t.ok(app._history.redo.calledOnce);
+  t.true(app._history.redo.calledOnce);
 });
 
 test('undo calls through to ImmutableHistory undo', t => {
@@ -144,7 +144,7 @@ test('undo calls through to ImmutableHistory undo', t => {
   t.plan(1);
 
   app.undo();
-  t.ok(app._history.undo.calledOnce);
+  t.true(app._history.undo.calledOnce);
 });
 
 test('undo calls through to ImmutableHistory canRedo', t => {
@@ -154,7 +154,7 @@ test('undo calls through to ImmutableHistory canRedo', t => {
   t.plan(1);
 
   app.canRedo();
-  t.ok(app._history.canRedo.calledOnce);
+  t.true(app._history.canRedo.calledOnce);
 });
 
 test('undo calls through to ImmutableHistory canUndo', t => {
@@ -164,7 +164,7 @@ test('undo calls through to ImmutableHistory canUndo', t => {
   t.plan(1);
 
   app.canUndo();
-  t.ok(app._history.canUndo.calledOnce);
+  t.true(app._history.canUndo.calledOnce);
 });
 
 test('fireActionCreator provides actionCreator with specified store state', t => {

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -84,9 +84,7 @@ test('fireActionCreator calls actionCreator with expected inputs', t => {
 });
 
 test('undo calls through to ImmutableHistory redo', t => {
-  const app = new App('test', [
-    TestStore,
-  ]);
+  const app = new App('test', [TestStore]);
 
   sinon.spy(app._history, 'redo');
   t.plan(1);


### PR DESCRIPTION
This PR moves `app.js` from 82.05% coverage to 100% for both lines and functions.

It also introduces Sinon.js for simple mocks, stubs and spies to enable easy future testing.